### PR TITLE
fix custom feature creation

### DIFF
--- a/FingerJoints.py
+++ b/FingerJoints.py
@@ -131,11 +131,12 @@ class CreateFingerJointCommand(FingerJointCommand):
 
         # Create an object holding the inputs, parameters, and dependencies for the new custom feature.
         customFeatureInput = activeComponent.features.customFeatures.createInput(
-            self.customFeatureDefinition, firstFeature, lastFeature)
+            self.customFeatureDefinition)
         self.options.storeInParameters(customFeatureInput)
         customFeatureInput.addDependency('body0', body0)
         customFeatureInput.addDependency('body1', body1)
         customFeatureInput.addDependency('direction', direction)
+        customFeatureInput.setStartAndEndFeatures(firstFeature, lastFeature)
 
         # Create the custom feature.
         activeComponent.features.customFeatures.add(customFeatureInput)


### PR DESCRIPTION
This commit fixes an issue, that `activeComponent.features.customFeatures.createInput` cannot be invoked with 3 parameters. Instead `setStartAndEndFeatures` should be used.