### PR TITLE
feat(update): added update fingerjoint command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /__pycache__
 /defaults.json
 .env
+*.log

--- a/FingerJoints.py
+++ b/FingerJoints.py
@@ -9,35 +9,69 @@
 # Some inspiration was taken from the dogbone add-in developed by Peter
 # Ludikar, Gary Singer, Patrick Rainsberry, David Liu, and Casey Rogers.
 
+from typing import Optional, List, cast, Union
+
 import adsk.core
 import adsk.fusion
 
+from .options import FingerJointFeatureInput
+from .log import logger
+from .commands import Action
+from . import util
 from . import commands
 from . import options
 from . import ui
 from . import geometry
 
 # Global variable to hold the add-in (created in run(), destroyed in stop())
-addIn = None
+addIn: Optional[commands.AddIn] = None
+
+_app = adsk.core.Application.get()
+_design: adsk.fusion.Design = cast(adsk.fusion.Design, _app.activeProduct)
 
 
-def createBaseFeature(parentComponent, bRepBody, name):
+class Attribute:
+    GROUP_NAME = 'fingerJoint'
+    INPUT = 'input'
+    BODY0 = 'body0'
+    BODY1 = 'body1'
+    DIRECTION = 'direction'
+
+
+def createBaseFeature(parentComponent: adsk.fusion.Component, body0: adsk.fusion.BRepBody, body1: adsk.fusion.BRepBody, inputs: FingerJointFeatureInput):
     feature = parentComponent.features.baseFeatures.add()
     feature.startEdit()
-    parentComponent.bRepBodies.add(bRepBody, feature)
-    feature.name = name
+    parentComponent.bRepBodies.add(body0, feature)
+    parentComponent.bRepBodies.add(body1, feature)
+    feature.name = "fingerjoint tool"
+    feature.attributes.add(Attribute.GROUP_NAME, Attribute.INPUT, inputs.asJson())
+    feature.attributes.add(Attribute.GROUP_NAME, Attribute.BODY0, inputs.body0.entityToken)
+    feature.attributes.add(Attribute.GROUP_NAME, Attribute.BODY1, inputs.body1.entityToken)
+    feature.attributes.add(Attribute.GROUP_NAME, Attribute.DIRECTION, inputs.direction.entityToken)
     feature.finishEdit()
     return feature
 
+
 def createCutFeature(parentComponent, targetBody, toolBodyFeature):
     toolBodies = adsk.core.ObjectCollection.create()
-    assert(toolBodyFeature.bodies.count == 1)
+
     toolBodies.add(toolBodyFeature.bodies.item(0))
     cutInput = parentComponent.features.combineFeatures.createInput(targetBody, toolBodies)
     cutInput.operation = adsk.fusion.FeatureOperations.CutFeatureOperation
     cutInput.isNewComponent = False
+    cutInput.isKeepToolBodies = False
     cutFeature = parentComponent.features.combineFeatures.add(cutInput)
     return cutFeature
+
+
+def getEntity(token: str, type: str):
+    entities = _design.findEntityByToken(token)
+
+    if entities is None or len(entities) != 1:
+        logger.warn(f"Found {len(entities) if entities is not None else 0} for {type} for token {token}")
+        raise Exception('Cannot find entity')
+
+    return entities[0]
 
 
 class CreateFingerJointCommand(commands.RunningCommandBase):
@@ -73,19 +107,20 @@ class CreateFingerJointCommand(commands.RunningCommandBase):
         inputs = self.ui.createInputs()
         self.last_used_inputs = inputs
         toolBodies = geometry.createToolBodies(inputs)
-        if toolBodies == True:
-            # No cut is neccessary (bodies do not overlap).
+        if toolBodies is True:
+            # No cut is necessary (bodies do not overlap).
             return True
-        elif toolBodies == False:
+        elif toolBodies is False:
             # No cut is possible (e.g., because of invalid inputs).
             return False
         else:
             self.createCustomFeature(inputs, *toolBodies)
             return True
 
-    def createCustomFeature(self, inputs, toolBody0, toolBody1):
+    # noinspection PyMethodMayBeStatic
+    def createCustomFeature(self, inputs: FingerJointFeatureInput, toolBody0, toolBody1):
         app = adsk.core.Application.get()
-        activeComponent = app.activeProduct.activeComponent
+        activeComponent = cast(adsk.fusion.Design, app.activeProduct).activeComponent
         design = activeComponent.parentDesign
 
         # Temporarily switch to parametric design
@@ -94,10 +129,9 @@ class CreateFingerJointCommand(commands.RunningCommandBase):
 
         # We will later group all created features into a custom feature.
         # For that reason, we have to remember the first and last feature that is part of this group.
-        tool0Feature = createBaseFeature(activeComponent, toolBody0, "tool0")
-        createCutFeature(activeComponent, inputs.body0, tool0Feature)
-        tool1Feature = createBaseFeature(activeComponent, toolBody1, "tool1")
-        createCutFeature(activeComponent, inputs.body1, tool1Feature)
+        toolFeature = createBaseFeature(activeComponent, toolBody0, toolBody1, inputs)
+        createCutFeature(activeComponent, inputs.body0, toolFeature)
+        createCutFeature(activeComponent, inputs.body1, toolFeature)
 
         design.designType = previousDesignType
 
@@ -107,28 +141,111 @@ class CreateFingerJointCommand(commands.RunningCommandBase):
             self.last_used_inputs.writeDefaults()
 
 
+class UpdateFingerJointCommand(commands.RunningCommandBase):
+
+    @staticmethod
+    def updateFingerJoint(feature: adsk.fusion.BaseFeature, obj: adsk.fusion.TimelineObject) -> bool:
+        attributes: adsk.core.Attributes = feature.attributes
+
+        if not len(attributes.itemsByGroup(Attribute.GROUP_NAME)) > 0:
+            # not a finger joint feature
+            return True
+
+        logger.debug(f"update feature '{feature.name}' at index: {obj.index}")
+
+        inputAsJson = attributes.itemByName(Attribute.GROUP_NAME, Attribute.INPUT).value
+        if not obj.rollTo(False):
+            raise Exception('Cannot rollback history')
+
+        inputs = FingerJointFeatureInput.fromJson(inputAsJson)
+        inputs.body0 = getEntity(attributes.itemByName(Attribute.GROUP_NAME, Attribute.BODY0).value, 'body0')
+        inputs.body1 = getEntity(attributes.itemByName(Attribute.GROUP_NAME, Attribute.BODY1).value, 'body1')
+        inputs.direction = getEntity(attributes.itemByName(Attribute.GROUP_NAME, Attribute.DIRECTION).value, 'direction')
+
+        toolBodies = geometry.createToolBodies(inputs)
+
+        if toolBodies is True or toolBodies is False:
+            # No cut is necessary (bodies do not overlap).
+            # delete finger joint features created before
+            index = feature.timelineObject.index
+            cast(adsk.fusion.CombineFeature, _design.timeline.item(index + 2).entity).deleteMe()
+            cast(adsk.fusion.CombineFeature, _design.timeline.item(index + 1).entity).deleteMe()
+            cast(adsk.fusion.BaseFeature, _design.timeline.item(index).entity).deleteMe()
+
+            return False
+
+        body0, body1 = toolBodies
+
+        feature.startEdit()
+        feature.updateBody(feature.bodies[0], body0)
+        feature.updateBody(feature.bodies[1], body1)
+        feature.finishEdit()
+
+        return True
+
+    def onExecute(self, args):
+        app = adsk.core.Application.get()
+        design: adsk.fusion.Design = cast(adsk.fusion.Design, app.activeProduct)
+
+        def processFeature(obj: adsk.fusion.TimelineObject) -> bool:
+
+            if obj.entity.classType() == adsk.fusion.BaseFeature.classType():
+                feature = cast(adsk.fusion.BaseFeature, obj.entity)
+                return UpdateFingerJointCommand.updateFingerJoint(feature, obj)
+
+            return True
+
+        def processTimeline(timeline: Union[adsk.fusion.Timeline, adsk.fusion.TimelineGroup]) -> int:
+            count = 0
+
+            for obj in timeline:
+                if obj.isGroup:
+                    group = cast(adsk.fusion.TimelineGroup, obj)
+                    isCollapsed = group.isCollapsed
+                    group.isCollapsed = False
+                    processTimeline(group)
+                    group.isCollapsed = isCollapsed
+                else:
+                    if not processFeature(obj):
+                        count += 3
+
+            return count
+
+        position = design.timeline.markerPosition
+        deletionCount = 0
+        try:
+            deletionCount = processTimeline(design.timeline)
+        finally:
+            design.timeline.markerPosition = position - deletionCount
+
+
 class FingerJointAddIn(commands.AddIn):
-    COMMAND_ID = 'fpFingerJoints'
-    FEATURE_NAME = 'Finger Joint'
-    RESOURCE_FOLDER = 'resources/ui/command_button'
-    CREATE_TOOLTIP='Creates a finger joint from the overlap of two bodies'
-    EDIT_TOOLTIP='Edit finger joint'
-    PANEL_NAME='SolidModifyPanel'
-    RUNNING_CREATE_COMMAND_CLASS = CreateFingerJointCommand
+    def actions(self) -> List[Action]:
+        return [
+            Action('create', 'Create Finger Joint', 'Creates a finger joint from the overlap of two bodies', 'resources/ui/command_button', CreateFingerJointCommand),
+            Action('update', 'Update Finger Joints', 'Update finger joints', 'resources/ui/command_button', UpdateFingerJointCommand)
+        ]
+
+    def _prefix(self) -> str:
+        return 'fpFingerJoints'
 
 
-def run(context):
+def run(_context):
     global addIn
     try:
         if addIn is not None:
             stop({'IsApplicationClosing': False})
         addIn = FingerJointAddIn()
-        addIn.addToUI()
-    except:
-        ui.reportError('Uncaught exception', True)
+        addIn.addToUi()
+    except Exception as e:
+        logger.exception(e)
+        util.reportError('Uncaught exception', True)
 
 
-def stop(context):
+def stop(_context):
     global addIn
-    addIn.removeFromUI()
+
+    if addIn:
+        addIn.removeFromUI()
+
     addIn = None

--- a/commands.py
+++ b/commands.py
@@ -1,11 +1,16 @@
+from abc import ABC, abstractmethod
+from typing import List
+
 import adsk.core
 import adsk.fusion
 
-from . import ui
+from .log import logger
+from . import util
 
 # Keep track of all currently running commands in a global set, so their
 # callback handlers are not GC'd.
 running_commands = set()
+
 
 def makeForwardingHandler(handler_cls, callback):
     class ForwardingHandler(handler_cls):
@@ -16,8 +21,10 @@ def makeForwardingHandler(handler_cls, callback):
         def notify(self, args):
             try:
                 self.callback(args)
-            except:
-                ui.reportError('Callback method failed', True)
+            except Exception as e:
+                logger.exception(e)
+                util.reportError('Callback method failed', True)
+
     return ForwardingHandler(callback)
 
 
@@ -33,7 +40,7 @@ class RunningCommandBase(object):
         running_commands.add(self)
 
     def onCreate(self, args):
-        cmd = adsk.core.Command.cast(args.command)            
+        cmd = adsk.core.Command.cast(args.command)
 
         self._inputChangedHandler = makeForwardingHandler(
             adsk.core.InputChangedEventHandler, self.onInputChanged)
@@ -42,11 +49,11 @@ class RunningCommandBase(object):
         self._selectionHandler = makeForwardingHandler(
             adsk.core.SelectionEventHandler, self.onSelectionEvent)
         cmd.selectionEvent.add(self._selectionHandler)
-        
+
         self._validateHandler = makeForwardingHandler(
             adsk.core.ValidateInputsEventHandler, self.onValidate)
         cmd.validateInputs.add(self._validateHandler)
-        
+
         self._executeHandler = makeForwardingHandler(
             adsk.core.CommandEventHandler, self.onExecute)
         cmd.execute.add(self._executeHandler)
@@ -81,58 +88,80 @@ class RunningCommandBase(object):
         running_commands.remove(self)
 
 
-class AddIn(object):
+class Action(ABC):
+    def __init__(self, id: str, buttonName: str, toolTip: str, resource: str, commandClass) -> None:
+        super().__init__()
+        self.id = id
+        self.buttonName = buttonName
+        self.toolTip = toolTip
+        self.resource = resource
+        self.commandClass = commandClass
+
+
+def getCallbackForAction(action: Action):
+    def callback(args):
+        command_class: RunningCommandBase = action.commandClass(args)
+        command_class.onCreate(args)
+
+    return callback
+
+
+class AddIn(ABC):
     # Defaults that are None have to be overridden in derived classes.
-    COMMAND_ID = None
-    FEATURE_NAME = None
-    RESOURCE_FOLDER = None
-    CREATE_TOOLTIP=''
-    EDIT_TOOLTIP=''
-    PANEL_NAME=None
-    RUNNING_CREATE_COMMAND_CLASS = None
+    PANEL_NAME = 'SolidModifyPanel'
 
     def __init__(self):
         fusion = adsk.core.Application.get()
         self.fusionUI = fusion.userInterface
+        self._actions = self.actions()
+        self.handler = []
 
-        # Add handler for creating the feature.
-        self._createHandler = makeForwardingHandler(
-            adsk.core.CommandCreatedEventHandler, self._onCreate)
+    @abstractmethod
+    def actions(self) -> List[Action]:
+        pass
 
-    def _onCreate(self, args):
-        running_command = self.RUNNING_CREATE_COMMAND_CLASS(args)
-        running_command.onCreate(args)
+    @abstractmethod
+    def _prefix(self) -> str:
+        pass
 
-    def _getCreateButtonID(self):
-        return self.COMMAND_ID + 'Create'
-
-    def _getCreateButtonName(self):
-        return self.FEATURE_NAME
-
-    def addToUI(self):
+    def addToUi(self):
         # If there are existing instances of the button, clean them up first.
         try:
             self.removeFromUI()
-        except:
+        except Exception as e:
+            logger.exception(e)
             pass
 
-        # Create a command for creating the feature.
-        createCommandDefinition = self.fusionUI.commandDefinitions.addButtonDefinition(
-            self._getCreateButtonID(), self._getCreateButtonName(), self.CREATE_TOOLTIP, self.RESOURCE_FOLDER)
-        createCommandDefinition.commandCreated.add(self._createHandler)
+        prefix = self._prefix()
 
-        # Add a button to the UI.
-        panel = self.fusionUI.allToolbarPanels.itemById(self.PANEL_NAME)
-        buttonControl = panel.controls.addCommand(createCommandDefinition)
-        buttonControl.isPromotedByDefault = True
-        buttonControl.isPromoted = True
+        for action in self._actions:
+            commandDefinition = self.fusionUI.commandDefinitions.addButtonDefinition(
+                f"{prefix}_{action.id}", action.buttonName, action.toolTip, action.resource)
+
+            h = makeForwardingHandler(adsk.core.CommandCreatedEventHandler, getCallbackForAction(action))
+            self.handler.append(h)
+            commandDefinition.commandCreated.add(h)
+
+            # Add a button to the UI.
+            panel = self.fusionUI.allToolbarPanels.itemById(self.PANEL_NAME)
+            buttonControl = panel.controls.addCommand(commandDefinition)
+            buttonControl.isPromotedByDefault = True
+            buttonControl.isPromoted = True
 
     def removeFromUI(self):
-        createCommandDefinition = self.fusionUI.commandDefinitions.itemById(self._getCreateButtonID())
-        if createCommandDefinition:
-            createCommandDefinition.deleteMe()
 
-        panel = self.fusionUI.allToolbarPanels.itemById(self.PANEL_NAME)
-        buttonControl = panel.controls.itemById(self._getCreateButtonID())
-        if buttonControl:
-            buttonControl.deleteMe()
+        prefix = self._prefix()
+
+        for action in self._actions:
+            buttonId = f"{prefix}_{action.id}"
+
+            createCommandDefinition = self.fusionUI.commandDefinitions.itemById(buttonId)
+            if createCommandDefinition:
+                createCommandDefinition.deleteMe()
+
+            panel = self.fusionUI.allToolbarPanels.itemById(self.PANEL_NAME)
+            buttonControl = panel.controls.itemById(buttonId)
+            if buttonControl:
+                buttonControl.deleteMe()
+
+        self.handler = []

--- a/geometry.py
+++ b/geometry.py
@@ -1,3 +1,5 @@
+from typing import Union, cast
+
 import adsk.core
 import adsk.fusion
 
@@ -93,7 +95,7 @@ def createToolBody(body, slices, inputs, debug=False):
 
     if debug:
         app = adsk.core.Application.get()
-        root = app.activeProduct.rootComponent
+        root = cast(adsk.fusion.Design, app.activeProduct).rootComponent
         feature = root.features.baseFeatures.add()
         feature.startEdit()
         root.bRepBodies.add(targetBody, feature)
@@ -130,7 +132,7 @@ def createBodyFromOverlap(body0, body1):
     return overlapBody
 
 
-def createToolBodies(inputs):
+def createToolBodies(inputs) -> Union[bool, tuple[adsk.fusion.BRepBody, adsk.fusion.BRepBody]]:
     overlap = createBodyFromOverlap(inputs.body0, inputs.body1)
     coordinateSystem = CoordinateSystem(inputs.direction, overlap)
     coordinateSystem.transformToLocalCoordinates(overlap)

--- a/log.py
+++ b/log.py
@@ -1,0 +1,15 @@
+import logging
+import os
+
+logger = logging.getLogger("fingerjoints")
+logger.setLevel(logging.DEBUG)
+
+formatter = logging.Formatter(
+    "%(asctime)s ; %(name)s ; %(levelname)s ; %(lineno)d; %(message)s"
+)
+logHandler = logging.FileHandler(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "fingerjoints.log"), mode="w"
+)
+logHandler.setFormatter(formatter)
+logHandler.flush()
+logger.addHandler(logHandler)

--- a/ui.py
+++ b/ui.py
@@ -4,6 +4,7 @@ import adsk.core
 
 from .options import FingerJointFeatureInput, PlacementType, DynamicSizeType, FusionExpression
 
+
 class FingerJointUI(object):
     def __init__(self, inputs, defaults):
         app = adsk.core.Application.get()
@@ -218,11 +219,3 @@ class FingerJointUI(object):
             valid = False
         self.setInputErrorMessage(errorMessage)
         return valid
-
-
-def reportError(message, includeStacktrace=False):
-    fusion = adsk.core.Application.get()
-    fusionUI = fusion.userInterface
-    if includeStacktrace:
-        message = '{}\n\nStack trace:\n{}'.format(message, traceback.format_exc())
-    fusionUI.messageBox(message)

--- a/util.py
+++ b/util.py
@@ -1,0 +1,11 @@
+import traceback
+
+import adsk.core
+
+
+def reportError(message, includeStacktrace=False):
+    fusion = adsk.core.Application.get()
+    fusionUI = fusion.userInterface
+    if includeStacktrace:
+        message = '{}\n\nStack trace:\n{}'.format(message, traceback.format_exc())
+    fusionUI.messageBox(message)


### PR DESCRIPTION
# Added an update fingerjoint command

When fingerjoint are created, the tool body persists:
  * the settings as json string
  * body0, body1, direction as references

On execution of the update fingerjoint command all features of the timelime are iterated through. If the feature is a base feature and has the settings + references stored as an attribute of the feature, the tool bodies are recreated. As the combine features references the tool bodies, the finger joints update. 

If no tool body can be created the former fingerjoint features (toolbody + 2x combines) are removed.
